### PR TITLE
refactor DialogueViewBase to an interface

### DIFF
--- a/Samples/Space/SpaceSample.tscn
+++ b/Samples/Space/SpaceSample.tscn
@@ -142,7 +142,7 @@ MaxX = 1200
 
 [node name="DialogueRunner" parent="YarnSpinnerCanvasLayer" index="0"]
 yarnProject = ExtResource("1")
-startNode = "Saly"
+startNode = "Sally"
 
 [node name="LineText" parent="YarnSpinnerCanvasLayer/LineView/ViewControl" index="0"]
 theme_override_font_sizes/normal_font_size = 34

--- a/Samples/VisualNovel/VisualNovelSample.tscn
+++ b/Samples/VisualNovel/VisualNovelSample.tscn
@@ -91,6 +91,7 @@ textLanguageCode = "en"
 
 [node name="DialogueRunner" parent="YarnSpinnerCanvasLayer" index="0"]
 yarnProject = ExtResource("2")
+startNode = "Start"
 
 [node name="LineText" parent="YarnSpinnerCanvasLayer/LineView/ViewControl" index="0"]
 theme_override_font_sizes/normal_font_size = 34

--- a/addons/YarnDonut/Runtime/Views/DialogueViewBase.cs
+++ b/addons/YarnDonut/Runtime/Views/DialogueViewBase.cs
@@ -36,7 +36,7 @@ namespace YarnDonut
     /// </remarks>
     /// <seealso cref="LineProviderBehaviour"/>
     /// <seealso cref="DialogueRunner.dialogueViews"/>
-    public abstract partial class DialogueViewBase : Godot.Node
+    public interface DialogueViewBase
     {
         /// <summary>
         /// Represents the method that should be called when this view wants the
@@ -60,7 +60,7 @@ namespace YarnDonut
         /// next line of dialogue.
         /// </para>
         /// </remarks>
-        public Action requestInterrupt;
+        public Action requestInterrupt { get; set; }
 
         /// <summary>Called by the <see cref="DialogueRunner"/> to signal that
         /// dialogue has started.</summary>
@@ -74,7 +74,7 @@ namespace YarnDonut
         /// <para style="note">The default implementation of this method does
         /// nothing.</para>
         /// </remarks>
-        public virtual void DialogueStarted()
+        public void DialogueStarted()
         {
             // Default implementation does nothing.
         }
@@ -134,7 +134,7 @@ namespace YarnDonut
         /// <seealso cref="InterruptLine(LocalizedLine, Action)"/>
         /// <seealso cref="DismissLine(Action)"/>
         /// <seealso cref="RunOptions(DialogueOption[], Action{int})"/>
-        public virtual void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
+        public void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
         {
             // The default implementation does nothing, and immediately calls
             // onDialogueLineFinished.
@@ -189,7 +189,7 @@ namespace YarnDonut
         /// called after the line has finished being presented.</param>
         /// <seealso cref="RunLine(LocalizedLine, Action)"/>
         /// <seealso cref="DismissLine(Action)"/>
-        public virtual void InterruptLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
+        public void InterruptLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
         {
             // the default implementation does nothing
             onDialogueLineFinished?.Invoke();
@@ -232,7 +232,7 @@ namespace YarnDonut
         /// </remarks>
         /// <param name="onDismissalComplete">The method that should be called
         /// when the view has finished dismissing the line.</param>
-        public virtual void DismissLine(Action onDismissalComplete)
+        public void DismissLine(Action onDismissalComplete)
         {
             // The default implementation does nothing, and immediately calls
             // onDialogueLineFinished.
@@ -287,7 +287,7 @@ namespace YarnDonut
         /// displayed to the user.</param>
         /// <param name="onOptionSelected">A method that should be called when
         /// the user has made a selection.</param>
-        public virtual void RunOptions(DialogueOption[] dialogueOptions, Action<int> onOptionSelected)
+        public void RunOptions(DialogueOption[] dialogueOptions, Action<int> onOptionSelected)
         {
             // The default implementation does nothing.
         }
@@ -306,7 +306,7 @@ namespace YarnDonut
         /// <para style="note">The default implementation of this method does
         /// nothing.</para>
         /// </remarks>
-        public virtual void DialogueComplete()
+        public void DialogueComplete()
         {
             // Default implementation does nothing.
         }
@@ -354,7 +354,7 @@ namespace YarnDonut
         /// <para style="note">The default implementation of this method does
         /// nothing.</para>
         /// </remarks>
-        public virtual void UserRequestedViewAdvancement()
+        public void UserRequestedViewAdvancement()
         {
             // default implementation does nothing
         }

--- a/addons/YarnDonut/Runtime/Views/LineView.cs
+++ b/addons/YarnDonut/Runtime/Views/LineView.cs
@@ -233,7 +233,7 @@ namespace YarnDonut
     /// A Dialogue View that presents lines of dialogue, using Godot UI Controls
     /// elements.
     /// </summary>
-    public partial class LineView : DialogueViewBase
+    public partial class LineView : Node, DialogueViewBase
     {
         /// <summary>
         /// The Control that is the parent of all UI elements in this line view.
@@ -467,7 +467,7 @@ namespace YarnDonut
         }
 
         /// <inheritdoc/>
-        public override void DismissLine(Action onDismissalComplete)
+        public void DismissLine(Action onDismissalComplete)
         {
             currentLine = null;
 
@@ -494,7 +494,7 @@ namespace YarnDonut
         }
 
         /// <inheritdoc/>
-        public override void InterruptLine(LocalizedLine dialogueLine, Action onInterruptLineFinished)
+        public void InterruptLine(LocalizedLine dialogueLine, Action onInterruptLineFinished)
         {
             currentLine = dialogueLine;
 
@@ -565,8 +565,10 @@ namespace YarnDonut
             onInterruptLineFinished();
         }
 
+        public Action requestInterrupt { get; set; }
+
         /// <inheritdoc/>
-        public override void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
+        public void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
         {
             // Begin running the line asynchronously
             RunLineInternal(dialogueLine, onDialogueLineFinished);
@@ -746,7 +748,7 @@ namespace YarnDonut
         }
 
         /// <inheritdoc/>
-        public override void UserRequestedViewAdvancement()
+        public void UserRequestedViewAdvancement()
         {
             // We received a request to advance the view. If we're in the middle of
             // an animation, skip to the end of it. If we're not current in an

--- a/addons/YarnDonut/Runtime/Views/OptionsListView.cs
+++ b/addons/YarnDonut/Runtime/Views/OptionsListView.cs
@@ -5,7 +5,7 @@ using Godot;
 
 namespace YarnDonut
 {
-    public partial class OptionsListView : DialogueViewBase
+    public partial class OptionsListView : Node, DialogueViewBase
     {
         [Export] PackedScene optionViewPrefab;
 
@@ -56,7 +56,9 @@ namespace YarnDonut
             viewControl.Visible = false;
         }
 
-        public override void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
+        public Action requestInterrupt { get; set; }
+
+        public void RunLine(LocalizedLine dialogueLine, Action onDialogueLineFinished)
         {
             // Don't do anything with this line except note it and
             // immediately indicate that we're finished with it. RunOptions
@@ -65,7 +67,7 @@ namespace YarnDonut
             onDialogueLineFinished();
         }
 
-        public override void RunOptions(DialogueOption[] dialogueOptions, Action<int> onOptionSelected)
+        public void RunOptions(DialogueOption[] dialogueOptions, Action<int> onOptionSelected)
         {
             viewControl.Visible = false;
             // Hide all existing option views

--- a/addons/YarnDonut/plugin.cfg
+++ b/addons/YarnDonut/plugin.cfg
@@ -3,5 +3,5 @@
 name="YarnDonut"
 description="Yarn language based dialogue system plugin for Godot"
 author="dogboydog"
-version="0.1.1"
+version="0.1.2"
 script="YarnDonutPlugin.cs"


### PR DESCRIPTION
This will allow  scripts implementing it to extend other Nodes such as Sprite2D. Views must still extend Node or some subclass thereof 

Also potentially fix an issue where the start node was being cleared from the DialogueRunner inspector