### PR TITLE
Use ToString() to format AggregateException

### DIFF
--- a/addons/YarnSpinner-Godot/Runtime/Views/LineView.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Views/LineView.cs
@@ -365,7 +365,7 @@ namespace YarnSpinnerGodot
                         var errorMessage = "";
                         if (failedTask.Exception != null)
                         {
-                            errorMessage =$"{failedTask.Exception.Message}\n{failedTask.Exception.StackTrace}";
+                            errorMessage = failedTask.Exception.ToString();
                         }
                         GD.PushError($"Error while running {nameof(RunLineInternal)}: {errorMessage}");
                     }, 

--- a/addons/YarnSpinner-Godot/Runtime/Views/OptionsListView.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Views/OptionsListView.cs
@@ -215,7 +215,7 @@ namespace YarnSpinnerGodot
                         var errorMessage = "";
                         if (failedTask.Exception != null)
                         {
-                            errorMessage =$"{failedTask.Exception.Message}\n{failedTask.Exception.StackTrace}";
+                            errorMessage = failedTask.Exception.ToString();
                         }
                         GD.PushError($"Error while running {nameof(Effects.FadeAlpha)}: {errorMessage}");
                     }, 


### PR DESCRIPTION
When catching an AggregateException from async tasks, the top level task does not include a stacktrace directly; it's inside the inner exception(s).

Emit the task by calling ToString() on the exception.

Before:
```
E 0:00:05:0149   void YarnSpinnerGodot.LineView+<>c.<RunLine>b__31_0(System.Threading.Tasks.Task): Error while running RunLineInternal: One or more errors occurred. (Object reference not set to an instance of an object.)

  <C# Source>    LineView.cs:371 @ void YarnSpinnerGodot.LineView+<>c.<RunLine>b__31_0(System.Threading.Tasks.Task)
  ...
```
After:
```
E 0:00:04:0424   void YarnSpinnerGodot.LineView+<>c.<RunLine>b__31_0(System.Threading.Tasks.Task): Error while running RunLineInternal: System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at YarnSpinnerGodot.LineView.<>c__DisplayClass32_0.<<RunLineInternal>g__PresentLine|0>d.MoveNext() in ...\addons\YarnSpinner-Godot\Runtime\Views\LineView.cs:line 382
--- End of stack trace from previous location ---
   at YarnSpinnerGodot.LineView.RunLineInternal(LocalizedLine dialogueLine, Action onDialogueLineFinished) in ...\addons\YarnSpinner-Godot\Runtime\Views\LineView.cs:line 505
   --- End of inner exception stack trace ---
  <C# Source>    LineView.cs:372 @ void YarnSpinnerGodot.LineView+<>c.<RunLine>b__31_0(System.Threading.Tasks.Task)
  ...
```