### PR TITLE
0.2.7 add explicit system.text.json dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.7] 2024-05-11
+* Add an explicit dependency on System.Text.Json v8.0.1 to fix compiler warnings and incompatibility with DotNet SDK versions below 8. The symptom in 0.2.6 was failing to create a .yarnproject file from the editor.
+
 ## [0.2.6] 2024-05-08 
 * Fix #53 where the first OptionView in an OptionsListView could not be interacted with if fadeTime was zero
 * Update YarnSpinner core DLL files to [version 2.4.2](https://github.com/YarnSpinnerTool/YarnSpinner/releases/tag/v2.4.2)

--- a/Samples/SQLiteVariableStorage/SQLVariableStorage.cs
+++ b/Samples/SQLiteVariableStorage/SQLVariableStorage.cs
@@ -68,6 +68,7 @@ public partial class SQLVariableStorage : VariableStorageBehaviour
         }
         else if (typeof(T) == typeof(float))
         {
+            
             query = "SELECT * FROM YarnFloat WHERE key = ?";
             results.AddRange(db.Query<YarnFloat>(query, variableName));
         }

--- a/addons/YarnSpinner-Godot/YarnSpinner-Godot.props
+++ b/addons/YarnSpinner-Godot/YarnSpinner-Godot.props
@@ -11,6 +11,7 @@
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.7.2"/>
         <PackageReference Include="CsvHelper" Version="12.2.2" />
         <PackageReference Include="Google.Protobuf" Version="3.25.2"/>
+        <PackageReference Include="System.Text.Json" Version="8.0.1" />
         <Reference Include="YarnSpinner">
             <HintPath>addons\YarnSpinner-Godot\Runtime\DLLs\YarnSpinner.dll</HintPath>
         </Reference>

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,5 +3,5 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="dogboydog"
-version="0.2.6"
+version="0.2.7"
 script="YarnSpinnerPlugin.cs"


### PR DESCRIPTION
A user wasn't able to create a yarn project with 0.2.6 with the Yarn Spinner core DLL update. I suspect maybe it's related to me having DotNet SDK 8 and maybe they have 6 ?   Hopefully this resolves the problem 