### PR TITLE
Fix optional parameters for commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.8] 2024-05-24
+* Fix Yarn commands not supporting methods with optional arguments (by @spirifoxy)
+* Update Visual Novel sample to make use of this fix
+
 ## [0.2.7] 2024-05-11
 * Add an explicit dependency on System.Text.Json v8.0.1 to fix compiler warnings and incompatibility with DotNet SDK versions below 8. The symptom in 0.2.6 was failing to create a .yarnproject file from the editor.
 

--- a/Samples/VisualNovel/Dialogue/VNExampleDialogue.yarn
+++ b/Samples/VisualNovel/Dialogue/VNExampleDialogue.yarn
@@ -9,7 +9,7 @@ position: 0,0
 // the node name must be specified - in this case VisualNovelManager
 <<Scene VisualNovelManager bg_office>>
 // start playing audioclip "ambient_birds" at 50% volume, loop forever
-<<PlayAudio ambient_birds 0.5 loop>>
+<<PlayAudio ambient_birds 0.5>>
 
 A VISUAL NOVEL EXAMPLE #line:07ee50d 
 
@@ -23,7 +23,7 @@ Eve: Finally, a quiet day at the office. Maybe I'll be able to get some work don
 
 // animate Adam into new position in right-half + center, within 0.5 seconds
 <<Move Adam right center 0.5>>
-<<PlayAudio music_funny 1.0 loop>>
+<<PlayAudio music_funny>>
 
 Adam: Hey Eve! I have a question! #line:07f4eac 
 Eve: Oh no... #line:0721506 
@@ -49,7 +49,7 @@ Eve: Oh no... #line:0721506
 
 Eve: Ok, now to finally write that visual novel. #line:0794753 
 <<Flip Eve left>>
-<<PlayAudio music_romantic 1.0 loop>>
+<<PlayAudio music_romantic>>
 Eve: I can finally write my epic romance about - #line:0c39b43 
 <<StopAudioAll>>
 <<Flip Eve right>>
@@ -59,7 +59,7 @@ Eve: Wait... where's my laptop? It's not here. #line:04432b5
 <<Shake Eve 1.0>>
 Eve: Adam! Have you seen my laptop??? #line:0a21105 
 
-<<PlayAudio music_funny 1.0 loop>>
+<<PlayAudio music_funny>>
 <<Flip Eve right>>
 <<Move Eve 1.25 center 1.0>>
 Eve: ADDDDAAAMMMMMMM!!! #line:062467b 

--- a/addons/YarnSpinner-Godot/Runtime/Commands/ActionManager.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Commands/ActionManager.cs
@@ -413,7 +413,7 @@ namespace YarnSpinnerGodot
             }
             for (int i = count; i < finalArgs.Length; i++)
             {
-                finalArgs[i] = Type.Missing;
+                finalArgs[i] = (parameters[i].HasDefaultValue ? parameters[i].DefaultValue : Type.Missing) ?? Type.Missing;
             }
             return finalArgs;
         }

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,5 +3,5 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="dogboydog"
-version="0.2.7"
+version="0.2.8"
 script="YarnSpinnerPlugin.cs"


### PR DESCRIPTION
When declaring commands with optional parameters, calling them omitting those parameters throws an exception.

Example:

```
 _dialogueRunner.AddCommandHandler<string, string>("Scene", Scene);
...

 private void Scene(string imageName, string alignment = "center") {
    ...
```

Calling this command as `<<Scene village_intro>>` will lead to this:
```
object System.Reflection.MethodBase.HandleTypeMissing(System.Reflection.ParameterInfo, System.RuntimeType): System.ArgumentException: Missing parameter does not have a default value. (Parameter 'parameters')
  <C++ Error>    System.ArgumentException
  <C++ Source>   :0 @ object System.Reflection.MethodBase.HandleTypeMissing(System.Reflection.ParameterInfo, System.RuntimeType)
  <Stack Trace>  :0 @ object System.Reflection.MethodBase.HandleTypeMissing(System.Reflection.ParameterInfo, System.RuntimeType)
                 :0 @ object System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(object, System.Reflection.BindingFlags, System.Reflection.Binder, System.Object[], System.Globalization.CultureInfo)
                 :0 @ object System.Delegate.DynamicInvokeImpl(System.Object[])
```

The fix is to send those default values directly instead of `Type.Missing`