### PR TITLE
0.2.9 - Fix problems with LineView's visibility / mouse filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.9] 2024-06-30
+
+* Set LineView's MouseFilter to 'ignore' to avoid interfering with clicks.  
+* Fix an issue where 'use fade effect' would cause the ConvertBBCodeToHTML feature to stop working while the text was fading out. 
+* Set the LineView to Visible=False when marking its alpha as 0.
+
 ## [0.2.8] 2024-05-24
 * Fix Yarn commands not supporting methods with optional arguments (by @spirifoxy)
 * Update Visual Novel sample to make use of this fix

--- a/addons/YarnSpinner-Godot/Scenes/DefaultDialogueSystem.tscn
+++ b/addons/YarnSpinner-Godot/Scenes/DefaultDialogueSystem.tscn
@@ -32,6 +32,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("3")
 viewControlPath = NodePath("ViewControl")
 useFadeEffect = false

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,5 +3,5 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="dogboydog"
-version="0.2.8"
+version="0.2.9"
 script="YarnSpinnerPlugin.cs"


### PR DESCRIPTION
* Set LineView's MouseFilter to 'ignore' to avoid interfering with clicks.  
* Fix an issue where 'use fade effect' would cause the ConvertBBCodeToHTML feature to stop working while the text was fading out. 
* Set the LineView to Visible=False when marking its alpha as 0.