### PR TITLE
v0.2.10 - system.text.json update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.10] 2024-07-11
+* Update System.Text.Json to 8.0.4 based on CVE-2024-30105 https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
+* Fix references to `RoundedViewStylebox.tres` that were in the wrong case in resource files, which could cause an issue on case-sensitive platforms.
+
 ## [0.2.9] 2024-06-30
 
 * Set LineView's MouseFilter to 'ignore' to avoid interfering with clicks.  

--- a/addons/YarnSpinner-Godot/Scenes/RoundedOptionView.tscn
+++ b/addons/YarnSpinner-Godot/Scenes/RoundedOptionView.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=4 format=3 uid="uid://dhnl6qatalt6x"]
 
-[ext_resource type="StyleBox" uid="uid://itxqi5xpilu6" path="res://addons/YarnSpinner-Godot/Scenes/RoundedViewStyleBox.tres" id="1_brfok"]
+[ext_resource type="StyleBox" uid="uid://itxqi5xpilu6" path="res://addons/YarnSpinner-Godot/Scenes/RoundedViewStylebox.tres" id="1_brfok"]
 [ext_resource type="Script" path="res://addons/YarnSpinner-Godot/Runtime/Views/OptionView.cs" id="1_uv0oc"]
-[ext_resource type="StyleBox" uid="uid://cqadffkf802cr" path="res://addons/YarnSpinner-Godot/Scenes/RoundedViewFocusedStyleBox.tres" id="2_tuu8c"]
+[ext_resource type="StyleBox" uid="uid://cqadffkf802cr" path="res://addons/YarnSpinner-Godot/Scenes/RoundedViewFocusedStylebox.tres" id="2_tuu8c"]
 
 [node name="OptionView" type="Button" node_paths=PackedStringArray("label")]
 anchors_preset = 7

--- a/addons/YarnSpinner-Godot/YarnSpinner-Godot.props
+++ b/addons/YarnSpinner-Godot/YarnSpinner-Godot.props
@@ -11,7 +11,7 @@
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.7.2"/>
         <PackageReference Include="CsvHelper" Version="12.2.2" />
         <PackageReference Include="Google.Protobuf" Version="3.25.2"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.1" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
         <Reference Include="YarnSpinner">
             <HintPath>addons\YarnSpinner-Godot\Runtime\DLLs\YarnSpinner.dll</HintPath>
         </Reference>

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,5 +3,5 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="dogboydog"
-version="0.2.9"
+version="0.2.10"
 script="YarnSpinnerPlugin.cs"


### PR DESCRIPTION
* Update System.Text.Json to 8.0.4 based on CVE-2024-30105 
* Fix references to `RoundedViewStylebox.tres` that were in the wrong case in resource files, which could cause an issue on case-sensitive platforms.