### PR TITLE
fix #62 - fade animation in options list view fixed. 

### DIFF
--- a/.github/workflows/continuous_build_check.yaml
+++ b/.github/workflows/continuous_build_check.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        godotVersion: ["4.1.4", "4.2.2"]
+        godotVersion: ["4.1.4", "4.2.2", "4.3.0"]
         targetFramework: ["net6.0", "net7.0"]
     name: Build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.11] 2024-09-13
+* Fix an issue where the OptionsListView did not fade in properly and instead suddenly appeared at the end of the fade time. (Fix #62)
+* `Effects.Fade` now uses a Godot Tween. 
+*  Grab focus of the first visible option in OptionsListView.cs, rather than the first option which may be hidden due to being unavailable.
+
 ## [0.2.10] 2024-07-11
 * Update System.Text.Json to 8.0.4 based on CVE-2024-30105 https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
 * Fix references to `RoundedViewStylebox.tres` that were in the wrong case in resource files, which could cause an issue on case-sensitive platforms.

--- a/Samples/SQLiteVariableStorage/SQLSample.tscn
+++ b/Samples/SQLiteVariableStorage/SQLSample.tscn
@@ -15,6 +15,13 @@ variableStorage = NodePath("../SQLVariableStorage")
 startNode = "SqlSample"
 startAutomatically = true
 
+[node name="LineView" parent="RoundedYarnSpinnerCanvasLayer" index="2"]
+useFadeEffect = true
+fadeInTime = 1.0
+
+[node name="OptionsListView" parent="RoundedYarnSpinnerCanvasLayer" index="3"]
+fadeTime = 2.0
+
 [node name="ColorRect" type="ColorRect" parent="RoundedYarnSpinnerCanvasLayer"]
 z_index = -6
 z_as_relative = false

--- a/addons/YarnSpinner-Godot/Runtime/Views/OptionsListView.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Views/OptionsListView.cs
@@ -1,6 +1,7 @@
 #nullable disable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Godot;
 
@@ -194,8 +195,8 @@ namespace YarnSpinnerGodot
                         OnOptionSelected(selectedOption.DialogueOptionID);
                     }
                 }
-
-                optionViews[0].GrabFocus();
+                // If the user is hiding unavailable options, select the first visible one.
+                optionViews.First(view => view.Visible).GrabFocus();
             }
             catch (Exception e)
             {

--- a/addons/YarnSpinner-Godot/Runtime/Views/OptionsListView.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Views/OptionsListView.cs
@@ -76,7 +76,7 @@ namespace YarnSpinnerGodot
             {
                 // prevent option views from being pressed by the same input that advanced the dialogue
                 // by waiting a frame
-                var mainTree = (SceneTree)Engine.GetMainLoop();
+                var mainTree = (SceneTree) Engine.GetMainLoop();
                 await mainTree.ToSignal(mainTree, SceneTree.SignalName.ProcessFrame);
                 viewControl.Visible = false;
                 // Hide all existing option views
@@ -152,6 +152,7 @@ namespace YarnSpinnerGodot
                 // Note the delegate to call when an option is selected
                 OnOptionSelected = onOptionSelected;
 
+                viewControl.Visible = true;
                 // Fade it all in
                 await Effects.FadeAlpha(viewControl, 0, 1, fadeTime);
 

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,5 +3,5 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="dogboydog"
-version="0.2.10"
+version="0.2.11"
 script="YarnSpinnerPlugin.cs"


### PR DESCRIPTION
Effects.Fade now uses a Godot tween, which should play nicer with pausing games. 
Demonstrate fade effects in SQL sample