### PR TITLE
Fix issue with DialogueRunner's type so now it can be seen in GDScript

### DIFF
--- a/addons/YarnSpinner-Godot/Runtime/DialogueRunner.cs
+++ b/addons/YarnSpinner-Godot/Runtime/DialogueRunner.cs
@@ -43,6 +43,7 @@ namespace YarnSpinnerGodot;
 /// The DialogueRunner component acts as the interface between your game and
 /// Yarn Spinner.
 /// </summary>
+[Tool]
 [GlobalClass]
 public partial class DialogueRunner : Godot.Node
 {


### PR DESCRIPTION
The issue I was having is that DialogueRunner's type was not seen in my GDScript, but another type like YarnProject IS seen in GDscript. After some further investigating and noticing I also couldn't see the InMemoryVariableStorage type I noticed that YarnProject had [Tool].

I'm not familar with [Tool] but it seems to expose things to be available in the Editor, I added it toDialogueRunner and now I can see the type in my GDScript and can use it within my variables