### PR TITLE
GDScript Yarn Example - Use basetype for DialogueRunner

### DIFF
--- a/Samples/GDScriptIntegration/CrossLanguageScriptingExample.gd
+++ b/Samples/GDScriptIntegration/CrossLanguageScriptingExample.gd
@@ -2,7 +2,7 @@
 # components from GDScript. 
 
 extends Control
-@export var dialogue_runner: DialogueRunner  
+@export var dialogue_runner: Node  
 @export var logo: Control 
 @export var yarn_project: YarnProject
 func _ready() -> void:


### PR DESCRIPTION
The GDScriptIntegration example would run fine the first time I ran the dialogue then it would fail with an error saying the dialogue_runner was nill on the second run. Setting it to be it's base type Node fixes it.

If there is anything else I can change or test while I'm here let me know!