### PR TITLE
Fix null reference in AddCommandHandlerCallable when callable does not return an object

### DIFF
--- a/addons/YarnSpinner-Godot/Runtime/DialogueRunner.cs
+++ b/addons/YarnSpinner-Godot/Runtime/DialogueRunner.cs
@@ -534,7 +534,8 @@ public partial class DialogueRunner : Godot.Node
             var castArgs = CastToExpectedTypes(argTypes, commandName, handlerArgs);
 
             var current = handler.Call(castArgs.ToArray());
-            if (current.As<GodotObject>().GetClass() == "GDScriptFunctionState")
+            var currentGodotObject = current.As<GodotObject>();
+            if (currentGodotObject != null && currentGodotObject.GetClass() == "GDScriptFunctionState")
             {
                 // callable is from GDScript with await statements
                 await ((SceneTree) Engine.GetMainLoop()).ToSignal(current.AsGodotObject(), "completed");


### PR DESCRIPTION
When registering a command without a return value or that returns primitives, handling the command fails with a null reference exception when awaiting the asynchronous task. This fix only checks for an asynchronous callable if the return type is a GodotObject.