### PR TITLE
v0.3.4   Bug fixes, persist variable storage source generation in import settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.3.4] 2025-07-x
+## [0.3.4] 2025-06-29
 
 * Fix fade up variable not being used for LinePresenter (PR #97 by @spirifoxy)
 * Fix errors when using `IGeneratedVariableStorage.GetEnumValueOrDefault` related to casting floats to uint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.4] 2025-07-x
+
+* Fix fade up variable not being used for LinePresenter (PR #97 by @spirifoxy)
+* Fix errors when using `IGeneratedVariableStorage.GetEnumValueOrDefault` related to casting floats to uint
+* fix #98 - use import settings for variable storage source generation so that those settings are version controlled
+
 ## [0.3.3] 2025-06-12
 
 * Update YarnSpinner DLLs to 3.0.2
@@ -14,7 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Updated
 
 * Fixed a bug where interpolated boolean values inside markup were being incorrectly determined as a string and not a bool.
-
 
 ## [0.3.2] 2025-05-25
 

--- a/Samples/SampleEntryPoint.tscn
+++ b/Samples/SampleEntryPoint.tscn
@@ -67,7 +67,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_font_sizes/normal_font_size = 28
 bbcode_enabled = true
-text = "0.3.2"
+text = "0.3.3"
 script = ExtResource("2_shsu2")
 
 [node name="Logo" type="TextureRect" parent="."]

--- a/Samples/Space/Dialogue/SpaceYarnProject.yarnproject.import
+++ b/Samples/Space/Dialogue/SpaceYarnProject.yarnproject.import
@@ -12,3 +12,7 @@ dest_files=["res://.godot/imported/SpaceYarnProject.yarnproject-a079bc9c48189d15
 
 [params]
 
+generateVariablesSourceFile=true
+variablesClassName="SpaceYarnVariables"
+variablesClassNamespace=""
+variablesClassParent="YarnSpinnerGodot.InMemoryVariableStorage"

--- a/addons/YarnSpinner-Godot/Editor/YarnProjectEditorUtility.cs
+++ b/addons/YarnSpinner-Godot/Editor/YarnProjectEditorUtility.cs
@@ -413,7 +413,7 @@ public static class YarnProjectEditorUtility
         {
             project.JSONProjectPath = project.DefaultJSONProjectPath;
         }
-        
+
         var saveErr = ResourceSaver.Save(project, project.ImportPath);
         if (saveErr != Error.Ok)
         {
@@ -942,7 +942,7 @@ public static class YarnProjectEditorUtility
             return false;
         }
 
-        var sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder();
         int indentLevel = 0;
         const int indentSize = 4;
 
@@ -998,16 +998,9 @@ public static class YarnProjectEditorUtility
 
             WriteGeneratedCodeAttribute();
 
-            if (type.RawType == Types.String)
-            {
-                // String-backed enums are represented as CRC32 hashes of
-                // the raw value, which we store as uints
-                WriteLine($"public enum {type.Name} : uint {{");
-            }
-            else
-            {
-                WriteLine($"public enum {type.Name} {{");
-            }
+            // Enums are always stored as integers; strings are represented
+            // as CRC32 hashes of the raw value
+            WriteLine($"public enum {type.Name} {{");
 
             indentLevel += 1;
 
@@ -1038,7 +1031,11 @@ public static class YarnProjectEditorUtility
                     WriteLine($"/// </remarks>");
                     var stringValue = (string)enumCase.Value.Value;
                     WriteComment($"\"{stringValue}\"");
-                    WriteLine($"{enumCase.Key} = {CRC32.GetChecksum(stringValue)},");
+                    // Get the hash of the string, and convert it to a
+                    // signed integer. (Unity doesn't correctly handle enums
+                    // whose backing value is a uint (values over signed
+                    // integer max are clamped to zero), so we'll cast it here.)
+                    WriteLine($"{enumCase.Key} = {(int)CRC32.GetChecksum(stringValue)},");
                 }
                 else
                 {

--- a/addons/YarnSpinner-Godot/Editor/YarnProjectImporter.cs
+++ b/addons/YarnSpinner-Godot/Editor/YarnProjectImporter.cs
@@ -58,7 +58,39 @@ public partial class YarnProjectImporter : EditorImportPlugin
 
     public override Array<Dictionary> _GetImportOptions(string path, int presetIndex)
     {
-        return new Array<Dictionary>();
+        return
+        [
+            new Dictionary
+            {
+                ["name"] = nameof(YarnProject.generateVariablesSourceFile),
+                ["default_value"] = false,
+            },
+            new Dictionary
+            {
+                ["name"] = nameof(YarnProject.variablesClassName),
+                ["default_value"] = "YarnVariables",
+            },
+            new Dictionary
+            {
+                ["name"] = nameof(YarnProject.variablesClassNamespace),
+                ["default_value"] = "",
+            },
+            new Dictionary
+            {
+                ["name"] = nameof(YarnProject.variablesClassParent),
+                ["default_value"] = typeof(InMemoryVariableStorage).FullName,
+            },
+        ];
+    }
+
+    public override bool _GetOptionVisibility(string path, StringName optionName, Dictionary options)
+    {
+        if (optionName == nameof(YarnProject.generateVariablesSourceFile))
+        {
+            return true;
+        }
+
+        return options.GetValueOrDefault(nameof(YarnProject.generateVariablesSourceFile), false).AsBool();
     }
 
     public override Error _Import(
@@ -86,6 +118,15 @@ public partial class YarnProjectImporter : EditorImportPlugin
         godotProject.JSONProjectPath = assetPath;
         godotProject.ImportPath = fullSavePath;
         godotProject.ResourceName = Path.GetFileName(assetPath);
+        godotProject.generateVariablesSourceFile =
+            options.GetValueOrDefault(nameof(YarnProject.generateVariablesSourceFile), false).AsBool();
+        godotProject.variablesClassName =
+            options.GetValueOrDefault(nameof(YarnProject.variablesClassName), "").AsString();
+        godotProject.variablesClassNamespace =
+            options.GetValueOrDefault(nameof(YarnProject.variablesClassNamespace), "").AsString();
+        godotProject.variablesClassParent =
+            options.GetValueOrDefault(nameof(YarnProject.variablesClassParent), nameof(InMemoryVariableStorage))
+                .AsString();
         var saveErr = ResourceSaver.Save(godotProject, godotProject.ImportPath);
         if (saveErr != Error.Ok)
         {
@@ -96,6 +137,5 @@ public partial class YarnProjectImporter : EditorImportPlugin
 
         return (int)Error.Ok;
     }
-
 }
 #endif

--- a/addons/YarnSpinner-Godot/Editor/YarnProjectInspectorPlugin.cs
+++ b/addons/YarnSpinner-Godot/Editor/YarnProjectInspectorPlugin.cs
@@ -197,6 +197,9 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
 
             if (path == nameof(YarnProject.generateVariablesSourceFile))
             {
+                const string editInstructions =
+                    "\nEdit settings related to variable storage source generation in " +
+                    "the Import panel for this Yarn project.";
                 var generationEnabledCheckbox = new CheckBox
                 {
                     Text = "Generate variables source file",
@@ -204,8 +207,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     Disabled = true,
                     TooltipText =
                         "Automatically generate a C# script with getters and setters for each variable declared " +
-                        "in this project. Edit settings related to variable storage source generation in " +
-                        "the Import panel for this Yarn project."
+                        $"in this project. {editInstructions}"
                 };
                 generationEnabledCheckbox.Toggled += OnGenerateVariablesSourceToggled;
                 AddCustomControl(generationEnabledCheckbox);
@@ -215,7 +217,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     var classNameHbox = new HBoxContainer
                     {
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
-                        TooltipText = "The name of the generated variables storage class."
+                        TooltipText = $"The name of the generated variables storage class. {editInstructions}"
                     };
 
                     var classNameLabel = new Label
@@ -235,7 +237,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     var classNamespaceHbox = new HBoxContainer
                     {
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
-                        TooltipText = "The namespace of the generated variables storage class."
+                        TooltipText = $"The namespace of the generated variables storage class. {editInstructions}"
                     };
 
                     var classNamespaceLabel = new Label
@@ -255,7 +257,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     var parentHbox = new HBoxContainer
                     {
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
-                        TooltipText = "The parent class the generated variables storage class will inherit from."
+                        TooltipText = $"The parent class the generated variables storage class will inherit from. {editInstructions}"
                     };
 
                     var parentLabel = new Label
@@ -273,7 +275,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     AddCustomControl(parentHbox);
                     AddCustomControl(new Label
                     {
-                        Text = "The file will be generated the next time the project is reimported, " +
+                        Text = "The file will be generated each time the project is reimported, " +
                                "or if you press the \"Re-compile Scripts in Project\" button above.",
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
                         AutowrapMode = TextServer.AutowrapMode.WordSmart,

--- a/addons/YarnSpinner-Godot/Editor/YarnProjectInspectorPlugin.cs
+++ b/addons/YarnSpinner-Godot/Editor/YarnProjectInspectorPlugin.cs
@@ -135,7 +135,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     SizeFlagsVertical = Control.SizeFlags.ExpandFill,
                 });
                 AddCustomControl(header);
-                if (_project.SerializedDeclarations is {Length: >= 1})
+                if (_project.SerializedDeclarations is { Length: >= 1 })
                 {
                     var scrollContainer = new ScrollContainer
                     {
@@ -197,8 +197,16 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
 
             if (path == nameof(YarnProject.generateVariablesSourceFile))
             {
-                var generationEnabledCheckbox = new CheckBox {Text = "Generate variables source file"};
-                generationEnabledCheckbox.ButtonPressed = _project.generateVariablesSourceFile;
+                var generationEnabledCheckbox = new CheckBox
+                {
+                    Text = "Generate variables source file",
+                    ButtonPressed = _project.generateVariablesSourceFile,
+                    Disabled = true,
+                    TooltipText =
+                        "Automatically generate a C# script with getters and setters for each variable declared " +
+                        "in this project. Edit settings related to variable storage source generation in " +
+                        "the Import panel for this Yarn project."
+                };
                 generationEnabledCheckbox.Toggled += OnGenerateVariablesSourceToggled;
                 AddCustomControl(generationEnabledCheckbox);
 
@@ -207,74 +215,61 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     var classNameHbox = new HBoxContainer
                     {
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                        TooltipText = "The name of the generated variables storage class."
                     };
-                    var classNameTooltip = "The name of the generated variables storage class.";
 
                     var classNameLabel = new Label
                     {
                         Text = "Variables class name",
-                        TooltipText = classNameTooltip,
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
                     };
-                    var classNameTextInput = new LineEdit
+                    var classNameValue = new Label
                     {
-                        PlaceholderText = "",
                         Text = _project.variablesClassName,
-                        TooltipText = classNameTooltip,
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
                     };
-                    classNameTextInput.TextChanged += VariablesClassNameTextChanged;
                     classNameHbox.AddChild(classNameLabel);
-                    classNameHbox.AddChild(classNameTextInput);
+                    classNameHbox.AddChild(classNameValue);
                     AddCustomControl(classNameHbox);
 
                     var classNamespaceHbox = new HBoxContainer
                     {
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                        TooltipText = "The namespace of the generated variables storage class."
                     };
-                    var classNamespaceTooltip =
-                        "The namespace of the generated variables storage class.";
 
                     var classNamespaceLabel = new Label
                     {
                         Text = "Variables class namepace",
-                        TooltipText = classNamespaceTooltip,
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
                     };
-                    var classNamespaceTextInput = new LineEdit
+                    var classNamespaceValue = new Label
                     {
-                        PlaceholderText = "",
                         Text = _project.variablesClassNamespace,
-                        TooltipText = classNamespaceTooltip,
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
                     };
-                    classNamespaceTextInput.TextChanged += VariablesClassNamespaceTextChanged;
                     classNamespaceHbox.AddChild(classNamespaceLabel);
-                    classNamespaceHbox.AddChild(classNamespaceTextInput);
+                    classNamespaceHbox.AddChild(classNamespaceValue);
                     AddCustomControl(classNamespaceHbox);
 
                     var parentHbox = new HBoxContainer
                     {
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                        TooltipText = "The parent class the generated variables storage class will inherit from."
                     };
-                    var parentTooltip = "The parent class the generated variables storage class will inherit from.";
 
                     var parentLabel = new Label
                     {
                         Text = "Variables class parent",
-                        TooltipText = parentTooltip,
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
                     };
-                    var parentTextInput = new LineEdit
+                    var parentValue = new Label
                     {
-                        PlaceholderText = "",
                         Text = _project.variablesClassParent,
-                        TooltipText = parentTooltip,
                         SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
                     };
-                    parentTextInput.TextChanged += VariablesClassParentTextChanged;
                     parentHbox.AddChild(parentLabel);
-                    parentHbox.AddChild(parentTextInput);
+                    parentHbox.AddChild(parentValue);
                     AddCustomControl(parentHbox);
                     AddCustomControl(new Label
                     {
@@ -285,7 +280,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                     });
                 }
 
-                AddCustomControl(new HSeparator {SizeFlagsHorizontal = Control.SizeFlags.ExpandFill});
+                AddCustomControl(new HSeparator { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill });
                 return true;
             }
 
@@ -394,7 +389,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
     {
         try
         {
-            _project = (YarnProject) @object;
+            _project = (YarnProject)@object;
             if (IsTresYarnProject(_project))
             {
                 AddCustomControl(new Label
@@ -415,7 +410,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                 Yarn.Compiler.Project.LoadFromFile(
                     ProjectSettings.GlobalizePath(_project.JSONProjectPath));
 
-            var yarnProjectVersionLabel = new Label {Text = $"Language Version: {_project.JSONProject.FileVersion}"};
+            var yarnProjectVersionLabel = new Label { Text = $"Language Version: {_project.JSONProject.FileVersion}" };
             AddCustomControl(yarnProjectVersionLabel);
             var recompileButton = new Button
             {
@@ -460,9 +455,9 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
             foreach (var pattern in _project.JSONProject.SourceFilePatterns)
             {
                 scriptPatternsGrid.AddChild(new Label()); // spacer
-                scriptPatternsGrid.AddChild(new Label {Text = pattern});
+                scriptPatternsGrid.AddChild(new Label { Text = pattern });
                 var patternDeleteButton = new SourcePatternDeleteButton
-                    {Text = "x", Project = _project, Pattern = pattern};
+                    { Text = "x", Project = _project, Pattern = pattern };
 
                 scriptPatternsGrid.AddChild(patternDeleteButton);
             }
@@ -500,7 +495,7 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                 SizeFlagsVertical = Control.SizeFlags.ExpandFill,
                 SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
             };
-            matchingScriptsHeader.AddChild(new Label {Text = "Matching Scripts"});
+            matchingScriptsHeader.AddChild(new Label { Text = "Matching Scripts" });
             matchingScriptsHeader.AddChild(new Label
             {
                 Text = numScriptsText,
@@ -525,17 +520,17 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
             AddCustomControl(_sourceScriptsListLabel);
 
             var localeGrid = new GridContainer
-                {SizeFlagsHorizontal = Control.SizeFlags.ExpandFill};
+                { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
             localeGrid.Columns = 3;
 
-            var label = new Label {Text = "Localization CSVs"};
+            var label = new Label { Text = "Localization CSVs" };
             localeGrid.AddChild(label);
 
             _localeTextEntry = new LineEditWithSubmit
             {
                 PlaceholderText = "locale code",
                 SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
-                SubmitButton = new Button {Text = "Add"},
+                SubmitButton = new Button { Text = "Add" },
             };
             localeGrid.AddChild(_localeTextEntry);
 
@@ -568,14 +563,14 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                 pathLabel.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
                 pathLabel.ClipText = true;
                 picker.AddChild(pathLabel);
-                var pickerButton = new Button {Text = "Browse"};
+                var pickerButton = new Button { Text = "Browse" };
                 _pendingCSVFileLocaleCode = locale.Key;
                 pickerButton.Connect(BaseButton.SignalName.Pressed,
                     Callable.From(SelectLocaleCSVPath));
                 picker.AddChild(pickerButton);
                 localeGrid.AddChild(picker);
                 var deleteButton = new LocaleDeleteButton
-                    {Text = "X", LocaleCode = locale.Key, Plugin = this};
+                    { Text = "X", LocaleCode = locale.Key, Plugin = this };
                 deleteButton.Connect(BaseButton.SignalName.Pressed,
                     new Callable(deleteButton,
                         nameof(LocaleDeleteButton.OnPressed)));
@@ -588,9 +583,9 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
             {
                 SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
             };
-            baseLocaleRow.AddChild(new Label {Text = "Base language"});
+            baseLocaleRow.AddChild(new Label { Text = "Base language" });
 
-            var changeBaseLocaleButton = new Button {Text = "Change"};
+            var changeBaseLocaleButton = new Button { Text = "Change" };
             _baseLocaleInput = new LineEditWithSubmit
             {
                 Text = _project.JSONProject.BaseLanguage,

--- a/addons/YarnSpinner-Godot/Runtime/IGeneratedVariableStorage.cs
+++ b/addons/YarnSpinner-Godot/Runtime/IGeneratedVariableStorage.cs
@@ -80,21 +80,32 @@ public static class GeneratedVariableStorageExtensions
             return default;
         }
 
-        uint caseValue;
+        int caseValue;
 
-        if (result.GetType() == typeof(string))
+        if (result is string stringResult)
         {
             // Convert the string value to a hash
-            caseValue = CRC32.GetChecksum((string) result);
+
+            caseValue = (int)CRC32.GetChecksum(stringResult);
+        }
+        else if (result is float floatResult)
+        {
+            caseValue = (int)floatResult;
+        }
+        else if (result is int intResult)
+        {
+            caseValue = intResult;
         }
         else
         {
-            caseValue = (uint) result;
+            GD.PushError(
+                $"Failed to get a value of type {typeof(T).Name} for variable {variableName}: received an unexpected variable type {result.GetType()} from variable storage");
+            return default;
         }
 
         if (Enum.IsDefined(typeof(T), caseValue))
         {
-            return (T) Enum.ToObject(typeof(T), caseValue);
+            return (T)Enum.ToObject(typeof(T), caseValue);
         }
         else
         {

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,6 +3,6 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="Decrepit Games"
-version="0.3.3"
+version="0.3.4"
 script="YarnSpinnerPlugin.cs"
 language="c-sharp"


### PR DESCRIPTION
## [0.3.4] 2025-06-29

* Fix fade up variable not being used for LinePresenter (PR #97 by @spirifoxy)
* Fix errors when using `IGeneratedVariableStorage.GetEnumValueOrDefault` related to casting floats to uint
* fix #98 - use import settings for variable storage source generation so that those settings are version controlled
![image](https://github.com/user-attachments/assets/2ff9e206-b895-4943-baf5-0a5522a875ae)



