### PR TITLE
Fix the last line text shown only once

### DIFF
--- a/addons/YarnSpinner-Godot/Runtime/Async/OptionsPresenter.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Async/OptionsPresenter.cs
@@ -95,7 +95,7 @@ public partial class OptionsPresenter : Node, DialoguePresenterBase
         lastSeenLine = null;
         if (IsInstanceValid(lastLineText))
         {
-            lastLineText!.Visible = false;
+            lastLineContainer.Visible = false;
         }
 
         if (IsInstanceValid(lastLineCharacterNameContainer))

--- a/addons/YarnSpinner-Godot/Runtime/Async/OptionsPresenter.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Async/OptionsPresenter.cs
@@ -93,7 +93,7 @@ public partial class OptionsPresenter : Node, DialoguePresenterBase
     public YarnTask OnDialogueCompleteAsync()
     {
         lastSeenLine = null;
-        if (IsInstanceValid(lastLineText))
+        if (IsInstanceValid(lastLineContainer))
         {
             lastLineContainer.Visible = false;
         }


### PR DESCRIPTION
**Issue**: When "Show Last Line" is enabled, the final line is shown once but does not appear in subsequent dialogues.
**Cause**: The last line text object was hidden directly instead of the line container, and it was never reset to visible.

