### PR TITLE
0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.3.10] 2025-TODO
+## [0.3.10] 2025-09-17
 
-* Improve DialogueRunner initialization by moving it back into _EnterTree, but prevent it from running multiple times
-* Update sample project to Godot 4.5 
+* Improve DialogueRunner initialization by moving it back into _EnterTree, but prevent it from running multiple times.
+* Update sample project to Godot 4.5.
+* Fix an issue where BasicMarkers in a MarkupPalette did not render correctly if they produced more than one BBCode tag (e.g. color, underline, and bold all in one marker).
 
 ## [0.3.9] 2025-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.10] 2025-TODO
+
+* Improve DialogueRunner initialization by moving it back into _EnterTree, but prevent it from running multiple times
+* Update sample project to Godot 4.5 
+
 ## [0.3.9] 2025-09-13
 
 * Revert change to DialogueRunner initialization from 0.3.8.
-* 
+
 ## [0.3.8] 2025-09-13
 
 * Add functionality to log any yarn project compilation errors at runtime, to make them more noticeable to users. To turn this off, uncheck Print Project Errors in your Dialogue Runner inspector.

--- a/Samples/Markup/example_markup_palette.tres
+++ b/Samples/Markup/example_markup_palette.tres
@@ -23,6 +23,7 @@ script = ExtResource("1_n23v5")
 Marker = "calm"
 CustomColor = true
 Color = Color(0.136169, 0.566038, 0.184834, 1)
+Italicised = true
 metadata/_custom_type_script = "uid://b3q2v7wyxccs0"
 
 [sub_resource type="Resource" id="Resource_kbrmq"]
@@ -30,6 +31,7 @@ script = ExtResource("1_n23v5")
 Marker = "hype"
 CustomColor = true
 Color = Color(0.754717, 0.162608, 0.0747597, 1)
+Boldened = true
 metadata/_custom_type_script = "uid://b3q2v7wyxccs0"
 
 [sub_resource type="Resource" id="Resource_oxr51"]
@@ -37,6 +39,8 @@ script = ExtResource("1_n23v5")
 Marker = "turbohype"
 CustomColor = true
 Color = Color(0.735849, 0.0173549, 0.722466, 1)
+Boldened = true
+Underlined = true
 metadata/_custom_type_script = "uid://b3q2v7wyxccs0"
 
 [sub_resource type="Resource" id="Resource_jh8x2"]

--- a/YarnSpinner-Godot.csproj
+++ b/YarnSpinner-Godot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.5.0-beta.2">
+<Project Sdk="Godot.NET.Sdk/4.5.0">
   <PropertyGroup>
     <NoWarn>RS2008</NoWarn> <!-- We do not have the AnalyserReleases.*.md files written to satisfy this warning -->
     <TargetFramework>net8.0</TargetFramework>

--- a/addons/YarnSpinner-Godot/Runtime/DialogueRunner.ActionRegistration.cs
+++ b/addons/YarnSpinner-Godot/Runtime/DialogueRunner.ActionRegistration.cs
@@ -9,22 +9,22 @@ public partial class DialogueRunner : IActionRegistration
 {
     /// <inheritdoc />
     public void AddCommandHandler(string commandName, Delegate handler) =>
-        CommandDispatcher.AddCommandHandler(commandName, handler);
+        CommandDispatcher!.AddCommandHandler(commandName, handler);
 
     /// <inheritdoc />
     public void AddCommandHandler(string commandName, MethodInfo method) =>
-        CommandDispatcher.AddCommandHandler(commandName, method);
+        CommandDispatcher!.AddCommandHandler(commandName, method);
 
     /// <inheritdoc />
-    public void RemoveCommandHandler(string commandName) => CommandDispatcher.RemoveCommandHandler(commandName);
+    public void RemoveCommandHandler(string commandName) => CommandDispatcher!.RemoveCommandHandler(commandName);
 
 
     /// <inheritdoc />
     public void AddFunction(string name, Delegate implementation) =>
-        CommandDispatcher.AddFunction(name, implementation);
+        CommandDispatcher!.AddFunction(name, implementation);
 
     /// <inheritdoc />
-    public void RemoveFunction(string name) => CommandDispatcher.RemoveFunction(name);
+    public void RemoveFunction(string name) => CommandDispatcher!.RemoveFunction(name);
     
     public void RegisterFunctionDeclaration(string name, Type returnType, Type[] parameterTypes) { /* no-op */ }
 

--- a/addons/YarnSpinner-Godot/Runtime/DialogueRunner.cs
+++ b/addons/YarnSpinner-Godot/Runtime/DialogueRunner.cs
@@ -337,8 +337,18 @@ public partial class DialogueRunner : Godot.Node
     private CancellationTokenSource? currentLineHurryUpSource;
 
     // Will be set in the constructor
-    private ICommandDispatcher CommandDispatcher { get; set; } = null!;
+    private ICommandDispatcher? CommandDispatcher { get; set; }
 
+
+    public override void _EnterTree()
+    {
+        if (CommandDispatcher == null)
+        {
+            var actions = new Actions(this, Dialogue.Library);
+            CommandDispatcher = actions;
+            actions.RegisterActions();
+        }
+    }
 
     /// <summary>
     /// Called by Godot to start running dialogue if <see cref="autoStart"/>
@@ -346,12 +356,9 @@ public partial class DialogueRunner : Godot.Node
     /// </summary>
     public override void _Ready()
     {
-        var actions = new Actions(this, Dialogue.Library);
-        CommandDispatcher = actions;
-        actions.RegisterActions();
         if (IsInstanceValid(VariableStorage) && IsInstanceValid(yarnProject))
         {
-            this.VariableStorage.Program = this.YarnProject!.Program; 
+            this.VariableStorage.Program = this.YarnProject!.Program;
         }
 
         if (IsInstanceValid(yarnProject))

--- a/addons/YarnSpinner-Godot/Runtime/Views/MarkupPalette.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Views/MarkupPalette.cs
@@ -57,40 +57,46 @@ public partial class MarkupPalette : Resource
             {
                 System.Text.StringBuilder front = new();
                 System.Text.StringBuilder back = new();
+                var closingTags = new Stack<string>();
 
                 // do we have a custom colour set?
                 if (item.CustomColor)
                 {
                     front.AppendFormat("[color=#{0}]", item.Color.ToHtml());
-                    back.Append("[/color]");
+                    closingTags.Push("[/color]");
                 }
 
                 // do we need to bold it?
                 if (item.Boldened)
                 {
                     front.Append("[b]");
-                    back.Append("[/b]");
+                    closingTags.Push("[/b]");
                 }
 
                 // do we need to italicise it?
                 if (item.Italicised)
                 {
                     front.Append("[i]");
-                    back.Append("[/i]");
+                    closingTags.Push("[/i]");
                 }
 
                 // do we need to underline it?
                 if (item.Underlined)
                 {
                     front.Append("[u]");
-                    back.Append("[/u]");
+                    closingTags.Push("[/u]");
                 }
 
                 // do we need to strikethrough it?
                 if (item.Strikedthrough)
                 {
                     front.Append("[s]");
-                    back.Append("[/s]");
+                    closingTags.Push("[/s]");
+                }
+
+                while (closingTags.Count > 0)
+                {
+                    back.Append(closingTags.Pop());
                 }
 
                 palette = new CustomMarker()

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,6 +3,6 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="Decrepit Games"
-version="0.3.9"
+version="0.3.10"
 script="YarnSpinnerPlugin.cs"
 language="c-sharp"


### PR DESCRIPTION
## [0.3.10] 2025-09-17

* Improve DialogueRunner initialization by moving it back into _EnterTree, but prevent it from running multiple times.
* Update sample project to Godot 4.5.
* Fix an issue where BasicMarkers in a MarkupPalette did not render correctly if they produced more than one BBCode tag (e.g. color, underline, and bold all in one marker).
