### PR TITLE
v0.3.12 - updates to markup processors for YS 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Update the base YarnSpinner libraries to 3.1.0. See details here: https://github.com/YarnSpinnerTool/YarnSpinner/releases/tag/v3.1.0
 * Removed the `ReplacementMarkupHandler.NoDiagnostics` static property, as this no longer matches any need due to core changes around replacement markup.
-* `ReplacementMarkuphandler` now returns a `ReplacementMarkerResult` instead of a list of diagnostics.
+* Breaking change: `ReplacementMarkuphandler` now returns a `ReplacementMarkerResult` instead of a list of diagnostics. Any custom ReplacementMarkupHandler will need to be updated. See `PaletteMarkerProcessor` as an example.
 * This is to match the behaviour change in core to fix a markup offset bug
 * Provide typed GDScript classes for LocalizedLine and MarkupParseResult Additional GDScript support for Presenters #111 by @KXI-System
+* Fix an issue where a CSV path would be applied to the wrong locale in the YarnProject inspector (#112)
 
 ## [0.3.11] 2025-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.3.11] 2025-xx-xx
+## [0.3.12] 2025-12-x
+
+* Update the base YarnSpinner libraries to 3.1.0. See details here: https://github.com/YarnSpinnerTool/YarnSpinner/releases/tag/v3.1.0
+* Removed the `ReplacementMarkupHandler.NoDiagnostics` static property, as this no longer matches any need due to core changes around replacement markup.
+* `ReplacementMarkuphandler` now returns a `ReplacementMarkerResult` instead of a list of diagnostics.
+* This is to match the behaviour change in core to fix a markup offset bug
+
+## [0.3.11] 2025-12-01
 
 * Port the solution to [this issue](https://github.com/YarnSpinnerTool/IssuesDiscussion/issues/32), making StartDialogue and Stop on the DialogueRunner async methods.
 * Add ChangeDialogue(string nodeName) method to the dialogue runner to allow stopping the dialogue, 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Removed the `ReplacementMarkupHandler.NoDiagnostics` static property, as this no longer matches any need due to core changes around replacement markup.
 * `ReplacementMarkuphandler` now returns a `ReplacementMarkerResult` instead of a list of diagnostics.
 * This is to match the behaviour change in core to fix a markup offset bug
+* Provide typed GDScript classes for LocalizedLine and MarkupParseResult Additional GDScript support for Presenters #111 by @KXI-System
 
 ## [0.3.11] 2025-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Removed the `ReplacementMarkupHandler.NoDiagnostics` static property, as this no longer matches any need due to core changes around replacement markup.
 * Breaking change: `ReplacementMarkuphandler` now returns a `ReplacementMarkerResult` instead of a list of diagnostics. Any custom ReplacementMarkupHandler will need to be updated. See `PaletteMarkerProcessor` as an example.
 * This is to match the behaviour change in core to fix a markup offset bug
-* Provide typed GDScript classes for LocalizedLine and MarkupParseResult Additional GDScript support for Presenters #111 by @KXI-System
+* Provide typed GDScript classes for LocalizedLine and MarkupParseResult Additional GDScript support for Presenters #111 and #113 by @KXI-System
 * Fix an issue where a CSV path would be applied to the wrong locale in the YarnProject inspector (#112)
 
 ## [0.3.11] 2025-12-01

--- a/Samples/Markup/ImageMarkupProcessor.cs
+++ b/Samples/Markup/ImageMarkupProcessor.cs
@@ -48,7 +48,7 @@ public partial class ImageMarkupProcessor : ReplacementMarkupHandler
         {
             // replace with <image tag> 
             childBuilder.Insert(0, value);
-            return new ReplacementMarkerResult();
+            return new ReplacementMarkerResult(value.Length);
         }
 
         if (marker.Name == "img")
@@ -77,7 +77,9 @@ public partial class ImageMarkupProcessor : ReplacementMarkupHandler
             var argsString = $"{widthString}{heightString}";
 
             // generic image markup
-            childBuilder.Insert(0, $"[img{argsString}]res://Samples/Markup/images/{imagePath.StringValue}[/img]");
+            var finalString = $"[img{argsString}]res://Samples/Markup/images/{imagePath.StringValue}[/img]";
+            childBuilder.Insert(0, finalString);
+            return new ReplacementMarkerResult(finalString.Length);
 
         }
 

--- a/Samples/Markup/ImageMarkupProcessor.cs
+++ b/Samples/Markup/ImageMarkupProcessor.cs
@@ -40,7 +40,7 @@ public partial class ImageMarkupProcessor : ReplacementMarkupHandler
         LineProvider.RegisterMarkerProcessor("img", this);
     }
 
-    public override List<LineParser.MarkupDiagnostic> ProcessReplacementMarker(MarkupAttribute marker,
+    public override ReplacementMarkerResult ProcessReplacementMarker(MarkupAttribute marker,
         StringBuilder childBuilder, List<MarkupAttribute> childAttributes,
         string localeCode)
     {
@@ -48,14 +48,18 @@ public partial class ImageMarkupProcessor : ReplacementMarkupHandler
         {
             // replace with <image tag> 
             childBuilder.Insert(0, value);
-            return [];
+            return new ReplacementMarkerResult();
         }
 
         if (marker.Name == "img")
         {
             if (!marker.TryGetProperty("path", out MarkupValue imagePath))
             {
-                return [new("No path attribute specified for img markup tag.")];
+                var error = new List<LineParser.MarkupDiagnostic>
+                {
+                    new LineParser.MarkupDiagnostic("No path attribute specified for img markup tag.")
+                };
+                return new ReplacementMarkerResult(error, 0);
             }
 
             var widthString = "";
@@ -75,9 +79,8 @@ public partial class ImageMarkupProcessor : ReplacementMarkupHandler
             // generic image markup
             childBuilder.Insert(0, $"[img{argsString}]res://Samples/Markup/images/{imagePath.StringValue}[/img]");
 
-            return NoDiagnostics;
         }
 
-        return [];
+        return new ReplacementMarkerResult();
     }
 }

--- a/Samples/Markup/MarkupSample.tscn
+++ b/Samples/Markup/MarkupSample.tscn
@@ -10,6 +10,95 @@
 [ext_resource type="Script" uid="uid://bqfgm8vm3snym" path="res://Samples/Markup/ImageMarkupProcessor.cs" id="7_ximcx"]
 [ext_resource type="AudioStream" uid="uid://befj7r1owf3qx" path="res://Samples/Markup/sounds/laugh.wav" id="8_oshmd"]
 
+[sub_resource type="Animation" id="Animation_ghmc3"]
+resource_name = "RESET"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("LaughTextParent:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0.033333335),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("LaughTextParent/LaughText1:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("LaughTextParent/LaughText2:visible")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("LaughTextParent/LaughText3:visible")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("LaughTextParent/LaughText4:visible")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("LaughTextParent/LaughText5:visible")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/6/type = "method"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("LaughAudio")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"stop"
+}]
+}
+
 [sub_resource type="Animation" id="Animation_irekb"]
 resource_name = "laugh"
 length = 3.0
@@ -97,95 +186,6 @@ tracks/6/keys = {
 "values": [{
 "args": [0.0],
 "method": &"play"
-}]
-}
-
-[sub_resource type="Animation" id="Animation_ghmc3"]
-resource_name = "RESET"
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("LaughTextParent:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0.033333335),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("LaughTextParent/LaughText1:visible")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("LaughTextParent/LaughText2:visible")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("LaughTextParent/LaughText3:visible")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/4/type = "value"
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/path = NodePath("LaughTextParent/LaughText4:visible")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/5/type = "value"
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/path = NodePath("LaughTextParent/LaughText5:visible")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/6/type = "method"
-tracks/6/imported = false
-tracks/6/enabled = true
-tracks/6/path = NodePath("LaughAudio")
-tracks/6/interp = 1
-tracks/6/loop_wrap = true
-tracks/6/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"values": [{
-"args": [],
-"method": &"stop"
 }]
 }
 

--- a/Samples/VisualNovel/Dialogue/VisualNovel.yarnproject
+++ b/Samples/VisualNovel/Dialogue/VisualNovel.yarnproject
@@ -15,5 +15,6 @@
     }
   },
   "baseLanguage": "en",
-  "compilerOptions": {}
+  "compilerOptions": {},
+  "definitionsFiles": []
 }

--- a/addons/YarnSpinner-Godot/Editor/YarnProjectInspectorPlugin.cs
+++ b/addons/YarnSpinner-Godot/Editor/YarnProjectInspectorPlugin.cs
@@ -580,9 +580,12 @@ public partial class YarnProjectInspectorPlugin : EditorInspectorPlugin
                 pathLabel.ClipText = true;
                 picker.AddChild(pathLabel);
                 var pickerButton = new Button { Text = "Browse" };
-                _pendingCSVFileLocaleCode = locale.Key;
-                pickerButton.Connect(BaseButton.SignalName.Pressed,
-                    Callable.From(SelectLocaleCSVPath));
+
+                pickerButton.Pressed += () =>
+                {
+                    _pendingCSVFileLocaleCode = locale.Key;
+                    SelectLocaleCSVPath();
+                };
                 picker.AddChild(pickerButton);
                 localeGrid.AddChild(picker);
                 var deleteButton = new LocaleDeleteButton

--- a/addons/YarnSpinner-Godot/Runtime/Async/PaletteMarkerProcessor.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Async/PaletteMarkerProcessor.cs
@@ -39,19 +39,23 @@ public partial class PaletteMarkerProcessor : ReplacementMarkupHandler
     /// apply, but this is ignored for TextMeshPro styles.</param>
     /// <param name="localeCode">The locale code to use when formatting the style.</param>
     /// <returns>A list of markup diagnostics if there are any errors, otherwise an empty list.</returns>
-    public override List<LineParser.MarkupDiagnostic> ProcessReplacementMarker(MarkupAttribute marker,
+    public override ReplacementMarkerResult ProcessReplacementMarker(MarkupAttribute marker,
         StringBuilder childBuilder, List<MarkupAttribute> childAttributes, string localeCode)
     {
         if (palette == null)
         {
-            var list = new List<LineParser.MarkupDiagnostic>
-                { new($"No palette set on {nameof(PaletteMarkerProcessor)}") };
-            return list;
+            var error = new List<LineParser.MarkupDiagnostic>
+            {
+                new LineParser.MarkupDiagnostic(
+                    $"can't apply palette for marker {marker.Name}, because a palette was not set")
+            };
+            return new ReplacementMarkerResult(error, 0);
         }
 
 
         if (palette.PaletteForMarker(marker.Name, out var format))
         {
+            var childrenLength = childBuilder.Length;
             childBuilder.Insert(0, format.Start);
             childBuilder.Append(format.End);
 
@@ -69,11 +73,20 @@ public partial class PaletteMarkerProcessor : ReplacementMarkupHandler
                 }
             }
 
-            return ReplacementMarkupHandler.NoDiagnostics;
+
+            // finally we need to calculate the number of invisible characters we added
+            // which is the difference between the new and original string lengths - the total number of visible characters inserted
+            // we don't care WHERE those visible characters were added, just that they were
+            // we can't just use the marker offset because that only worries about visible elements added at the front of the string
+            // most of the time this is just gonna be 0 anyways and you don't have to think about it
+            return new ReplacementMarkerResult(childBuilder.Length - childrenLength -
+                                               format.TotalVisibleCharacterCount);
         }
 
-        var diagnostic = new LineParser.MarkupDiagnostic($"was unable to find a matching marker for {marker.Name}");
-        return new List<LineParser.MarkupDiagnostic>() { diagnostic };
+        List<LineParser.MarkupDiagnostic> diagnostics =
+            [new($"was unable to find a matching marker for {marker.Name}")];
+
+        return new ReplacementMarkerResult(diagnostics, 0);
     }
 
     /// <summary>

--- a/addons/YarnSpinner-Godot/Runtime/Async/ReplacementMarkupHandler.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Async/ReplacementMarkupHandler.cs
@@ -16,12 +16,8 @@ namespace YarnSpinnerGodot;
 /// <seealso cref="LineProviderBehaviour"/>
 public abstract partial class ReplacementMarkupHandler : Node, IAttributeMarkerProcessor
 {
-    /// <summary>
-    /// An empty collection of diagnostics.
-    /// </summary>
-    public static readonly List<LineParser.MarkupDiagnostic> NoDiagnostics = [];
-
+    
     /// <inheritdoc/>
-    public abstract List<LineParser.MarkupDiagnostic> ProcessReplacementMarker(MarkupAttribute marker,
+    public abstract ReplacementMarkerResult ProcessReplacementMarker(MarkupAttribute marker,
         StringBuilder childBuilder, List<MarkupAttribute> childAttributes, string localeCode);
 }

--- a/addons/YarnSpinner-Godot/Runtime/CustomMarker.cs
+++ b/addons/YarnSpinner-Godot/Runtime/CustomMarker.cs
@@ -11,5 +11,6 @@ public partial class CustomMarker : Resource
     [Export] public string? Marker;
     [Export] public string? Start;
     [Export] public string? End;
-    [Export] public int MarkerOffset = 0;
+    [Export] public int MarkerOffset;
+    [Export] public int TotalVisibleCharacterCount;
 }

--- a/addons/YarnSpinner-Godot/Runtime/YarnProject.cs
+++ b/addons/YarnSpinner-Godot/Runtime/YarnProject.cs
@@ -101,7 +101,7 @@ public partial class YarnProject : Resource
     /// <seealso cref="generateVariablesSourceFile"/>
     /// <seealso cref="variablesClassNamespace"/>
     /// <seealso cref="variablesClassParent"/>
-    [Export] public string variablesClassName = "YarnVariables";
+    [Export] public string variablesClassName;
 
     /// <summary>
     /// The namespace of the generated variables storage class.
@@ -109,7 +109,7 @@ public partial class YarnProject : Resource
     /// <seealso cref="generateVariablesSourceFile"/>
     /// <seealso cref="variablesClassName"/>
     /// <seealso cref="variablesClassParent"/>
-    [Export] public string variablesClassNamespace = null;
+    [Export] public string variablesClassNamespace;
 
     /// <summary>
     /// The parent class of the generated variables storage class.
@@ -117,7 +117,7 @@ public partial class YarnProject : Resource
     /// <seealso cref="generateVariablesSourceFile"/>
     /// <seealso cref="variablesClassName"/>
     /// <seealso cref="variablesClassNamespace"/>
-    [Export] public string variablesClassParent = typeof(InMemoryVariableStorage).FullName;
+    [Export] public string variablesClassParent;
 
 #if TOOLS
     public string DefaultJSONProjectPath => new Regex(@"\.tres$").Replace(ResourcePath, ".yarnproject");

--- a/addons/YarnSpinner-Godot/YarnSpinner-Godot.props
+++ b/addons/YarnSpinner-Godot/YarnSpinner-Godot.props
@@ -17,8 +17,8 @@
         <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1"/>
         <PackageReference Include="CsvHelper" Version="12.3.2"/>
         <PackageReference Include="Google.Protobuf" Version="3.31.1"/>
-        <PackageReference Include="YarnSpinner" Version="3.0.2"/>
-        <PackageReference Include="YarnSpinner.Compiler" Version="3.0.2"/>
+        <PackageReference Include="YarnSpinner" Version="3.1.0"/>
+        <PackageReference Include="YarnSpinner.Compiler" Version="3.1.0"/>
         <ProjectReference Include="addons\YarnSpinner-Godot\SourceGenerator\YarnSpinnerGodotSourceGenerator.csproj"
                           ReferenceOutputAssembly="false"
                           OutputItemType="analyzer"/>

--- a/addons/YarnSpinner-Godot/plugin.cfg
+++ b/addons/YarnSpinner-Godot/plugin.cfg
@@ -3,6 +3,6 @@
 name="YarnSpinner-Godot"
 description="Yarn language based dialogue system plugin for Godot"
 author="Decrepit Games"
-version="0.3.11"
+version="0.3.12"
 script="YarnSpinnerPlugin.cs"
 language="c-sharp"


### PR DESCRIPTION
## [0.3.12] 2025-12-x

* Update the base YarnSpinner libraries to 3.1.0. See details here: https://github.com/YarnSpinnerTool/YarnSpinner/releases/tag/v3.1.0
* Removed the `ReplacementMarkupHandler.NoDiagnostics` static property, as this no longer matches any need due to core changes around replacement markup.
* Breaking change: `ReplacementMarkuphandler` now returns a `ReplacementMarkerResult` instead of a list of diagnostics. Any custom ReplacementMarkupHandler will need to be updated. See `PaletteMarkerProcessor` as an example.
* This is to match the behaviour change in core to fix a markup offset bug
* Provide typed GDScript classes for LocalizedLine and MarkupParseResult Additional GDScript support for Presenters #111 and #113 by @KXI-System
* Fix an issue where a CSV path would be applied to the wrong locale in the YarnProject inspector (#112)

