### PR TITLE
Additional GDScript support for Presenters

### DIFF
--- a/Samples/GDScriptIntegration/SimpleGDScriptLinePresenter.gd
+++ b/Samples/GDScriptIntegration/SimpleGDScriptLinePresenter.gd
@@ -19,9 +19,9 @@ func run_line_async(line: Dictionary) -> void:
 
 	# line is a Dictionary converted from the LocalizedLine C# Class
 	# converts to GDScript LocalizedLine
-	var localized_line : GDYS.LocalizedLine = GDYS.LocalizedLine.new(line)
+	var localized_line : YarnSpinner.LocalizedLine = YarnSpinner.LocalizedLine.from_dictionary(line)
 	
-	var target_line: GDYS.Line
+	var target_line: YarnSpinner.MarkupParseResult
 	if localized_line.character_name.is_empty():
 		character_name_label.visible = false
 		target_line = localized_line.text

--- a/Samples/GDScriptIntegration/SimpleGDScriptLinePresenter.gd
+++ b/Samples/GDScriptIntegration/SimpleGDScriptLinePresenter.gd
@@ -2,66 +2,46 @@
 # the help of a corresponding GDScriptViewAdapter node.s
 extends Node
 
-
 @export var continue_button : Button
 @export var character_name_label : RichTextLabel
 @export var line_text_label : RichTextLabel
 @export var presenter_control: Node 
 
-var line_finished: bool 
-
 func _ready() -> void: 
 	presenter_control.visible = false 
-	
+
 func on_dialogue_start_async() -> void:
 	print("Dialogue started ")
-	
-	
-func run_line_async(line: Dictionary) -> void:
-	# line is a Dictionary converted from the LocalizedLine C# Class
-	# example: 
-	# {"metadata":["my_metadata"],
-	# "text":
-		#  {
-		#  "attributes":[
-		#   	{ "length":8,"name":"fx","position":20,"properties":[{"type":"wave"}]},
-		#   	{ "length":6,"name":"character","position":0,"properties":[{"name":"Gary"}]}
-		#   ],
-		#   "text":"Gary: So, can I use GDScript with YarnSpinner?",
-		#   "text_without_character_name":"So, can I use GDScript with YarnSpinner?"
-		#  }
-	#  }
 	presenter_control.visible = true
-	line_finished = false
+
+func run_line_async(line: Dictionary) -> void:
 	print('Line: ' + JSON.stringify(line))
-	continue_button.pressed.connect(continue_line)
+
+	# line is a Dictionary converted from the LocalizedLine C# Class
+	# converts to GDScript LocalizedLine
+	var localized_line : GDYS.LocalizedLine = GDYS.LocalizedLine.new(line)
 	
-	line_text_label.text = line["text"]["text_without_character_name"]
-	var character_name : String = ""
-	var character_name_offset: int = 0 
-	for attribute: Dictionary in line["text"]["attributes"]:
-		if attribute["name"] == "character":
-			character_name = attribute["properties"][0]["name"]
-			character_name_offset = line["text"]["text"].find(line["text"]["text_without_character_name"])
-			break
-	for attribute: Dictionary in line["text"]["attributes"]:
-		# Example of using YarnSpinner markup like [fx type="wave"] in the yarn script.
-		if attribute["name"] == "fx": 
-			for property in attribute["properties"]:
-				if property["type"] == "wave":
-					var wave_begin = "[wave]"
-					line_text_label.text = line_text_label.text.insert(attribute["position"] - character_name_offset, wave_begin)
-					line_text_label.text = line_text_label.text.insert(attribute["position"] - character_name_offset + len(wave_begin) + attribute["length"], "[/wave]")
-	character_name_label.text = character_name
-	if not (character_name):
-		character_name_label.visible = false 
+	var target_line: GDYS.Line
+	if localized_line.character_name.is_empty():
+		character_name_label.visible = false
+		target_line = localized_line.text
+	else:
+		character_name_label.visible = true
+		character_name_label.text = localized_line.character_name
+		target_line = localized_line.text_without_character_name
 	
-	while !line_finished:
-		await get_tree().process_frame
-		
-func continue_line() -> void:
-	continue_button.pressed.disconnect(continue_line)
-	line_finished = true
+	var output_line: String = target_line.text
+
+	var fx_attribute = target_line.try_get_attribute_with_name("fx")
+	if not fx_attribute.is_empty():
+		for property in fx_attribute["properties"]:
+			if property["type"] == "wave":
+				output_line = output_line.insert(fx_attribute["position"] + fx_attribute["length"], "[/wave]")
+				output_line = output_line.insert(fx_attribute["position"], "[wave]")
+
+	line_text_label.text = output_line
+
+	await continue_button.pressed
 
 func dialogue_complete_async() -> void:
 	print("Dialogue complete ")

--- a/Samples/GDScriptIntegration/SimpleGDScriptOptionItem.gd
+++ b/Samples/GDScriptIntegration/SimpleGDScriptOptionItem.gd
@@ -2,7 +2,7 @@ class_name SimpleGDScriptOptionItem extends Button
 
 @export var label: RichTextLabel 
 
-func set_option(option: GDYS.DialogueOption, on_selected: Callable) -> void:
+func set_option(option: YarnSpinner.DialogueOption, on_selected: Callable) -> void:
 	label.text = option.line.text.text
 
 	pressed.connect(func() -> void:

--- a/Samples/GDScriptIntegration/SimpleGDScriptOptionItem.gd
+++ b/Samples/GDScriptIntegration/SimpleGDScriptOptionItem.gd
@@ -1,14 +1,10 @@
-extends Button
-class_name SimpleGDScriptOptionItem
+class_name SimpleGDScriptOptionItem extends Button
+
 @export var label: RichTextLabel 
 
-var option_dict: Dictionary
-var on_option_selected: Callable 
-func set_option(option: Dictionary, on_selected: Callable) -> void:
-	option_dict = option
-	label.text = option["line"]["text"]["text"]
-	on_option_selected = on_selected 
-	pressed.connect(on_pressed)
-	
-func on_pressed()-> void:
-	on_option_selected.call(option_dict["dialogue_option_id"])
+func set_option(option: GDYS.DialogueOption, on_selected: Callable) -> void:
+	label.text = option.line.text.text
+
+	pressed.connect(func() -> void:
+		on_selected.call(option.dialogue_option_id)
+	)

--- a/Samples/GDScriptIntegration/SimpleGDScriptOptionsPresenter.gd
+++ b/Samples/GDScriptIntegration/SimpleGDScriptOptionsPresenter.gd
@@ -16,7 +16,7 @@ func run_options_async(options: Array, on_option_selected: Callable) -> void:
 
 	# options is a Dictionary converted from the LocalizedLine C# Class
 	# converts to GDScript DialogueOptions array
-	var dialogue_options := GDYS.new_dialogue_option_array(options)
+	var dialogue_options := YarnSpinner.dialogue_options_from_array(options)
 
 	# You can do await statements here if you want.
 	await get_tree().process_frame

--- a/Samples/GDScriptIntegration/SimpleGDScriptOptionsPresenter.gd
+++ b/Samples/GDScriptIntegration/SimpleGDScriptOptionsPresenter.gd
@@ -1,56 +1,34 @@
-extends Node
 # Example of writing an options presenter in GDScript
+extends Node
+
 @export var option_item_prefab : PackedScene
 @export var options_container: Container
 @export var presenter_control: Control 
-
 var option_selected_handler: Callable 
-
 var option_selected : bool = false 
+
 func _ready() -> void: 
 	presenter_control.visible = false 
-	
-# Example options array: 
-#[
-	#{
-		#"dialogue_option_id": 0,
-		#"is_available": true,
-		#"line": {
-			#"metadata": [],
-			#"text": {
-				#"attributes": [],
-				#"text": "Yes",
-				#"text_without_character_name": "Yes"
-			#}
-		#},
-		#"text_id": "line:b7aaff9b"
-	#},
-	#{
-		#"dialogue_option_id": 1,
-		#"is_available": true,
-		#"line": {
-			#"metadata": [],
-			#"text": {
-				#"attributes": [],
-				#"text": "No",
-				#"text_without_character_name": "No"
-			#}
-		#},
-		#"text_id": "line:9bcbf175"
-	#}
-#]
+
 func run_options_async(options: Array, on_option_selected: Callable) -> void:
 	print("Options: %s"  % JSON.stringify(options))
 	option_selected = false
+
+	# options is a Dictionary converted from the LocalizedLine C# Class
+	# converts to GDScript DialogueOptions array
+	var dialogue_options := GDYS.new_dialogue_option_array(options)
+
 	# You can do await statements here if you want.
 	await get_tree().process_frame
 	option_selected_handler = on_option_selected
-	while options_container.get_child_count() >0:
+	while options_container.get_child_count() > 0:
 		options_container.remove_child(options_container.get_child(0))
-	for option in options:
-		if not option["is_available"]:
+
+	for option in dialogue_options:
+		if not option.is_available:
 			# don't render unvailable options
 			continue 
+
 		var option_item: SimpleGDScriptOptionItem = option_item_prefab.instantiate() 
 		option_item.set_option(option, select_option)
 		options_container.add_child(option_item)
@@ -62,6 +40,8 @@ func run_options_async(options: Array, on_option_selected: Callable) -> void:
 func select_option(option_id: int) -> void:
 	option_selected_handler.call(option_id)
 	presenter_control.visible = false 
+
 	while options_container.get_child_count() > 0:
 		options_container.remove_child(options_container.get_child(0))
+
 	option_selected = true

--- a/addons/YarnSpinner-Godot/Runtime/Views/GDScriptHelper.gd
+++ b/addons/YarnSpinner-Godot/Runtime/Views/GDScriptHelper.gd
@@ -1,0 +1,121 @@
+class_name GDYS
+## Helper class supporting C# to GDScript functionality
+##
+## This helper class creates GDScript versions of classes and other helper functions
+## to have parity with the YarnSpinner C# API.
+
+## Represents a dialogue option, ready to be presented to the user
+##
+## Constructor takes a dictionary structured the same way as provided
+## by the DialogueRunner for GDScript
+## Mirrors YarnSpinnerGodot.DialogueOption
+class DialogueOption:
+	var dialogue_option_id: int ## The ID of this dialogue option
+	var text_id: String ## The ID of the dialogue option's text
+	var line: LocalizedLine ## The line for this dialogue option
+	var is_available: bool ## Indicates whether this value should be presented as available
+
+	func _init(data: Dictionary = {}) -> void:
+		if data.is_empty(): return
+		if !data.has_all(["dialogue_option_id", "line"]):
+			push_error("YarnSpinner GDScript: Can't create DialogueOption, incorrect or missing data")
+			return
+
+		dialogue_option_id = data["dialogue_option_id"]
+		text_id = data["text_id"]
+		line = LocalizedLine.new(data["line"])
+		is_available = data["is_available"]
+
+
+## Represents a line, ready to be presented to the user in the localisation they have specified.
+##
+## Constructor takes a dictionary structured the same way as provided
+## by the DialogueRunner for GDScript
+## Mirrors YarnSpinnerGodot.LocalizedLine class
+class LocalizedLine:
+	var text: Line ## The underlying Line class for this line
+	var text_without_character_name: Line ## The original text with the character attribute removed
+	var text_id: String ## DialogueLine's ID
+	var raw_text: String ## DialogueLine's unparsed text
+	var substitutions: Array ## DialogueLine's inline expression's substitution
+	var metadata: Array ## Any metadata associated with this line.
+
+	## The name of the character, if present
+	var character_name: String:
+		get:
+			var name = text.try_get_attribute_with_name("character")
+			if name.is_empty():
+				return ""
+			else:
+				return name["properties"][0]["name"]
+
+	func _init(data: Dictionary = {}) -> void:
+		if data.is_empty(): return
+		if !data.has_all(["text", "metadata"]):
+			push_error("YarnSpinner GDScript: Can't create LocalizedLine, incorrect or missing data")
+			return
+
+		text = Line.new(data["text"])
+		text_without_character_name = Line.new(data["text_without_character_name"])
+		text_id = data["text_id"]
+		raw_text = data["raw_text"]
+		substitutions = data["substitutions"]
+		metadata = data["metadata"]
+
+
+## Line mirroring the MarkupParseResult values
+##
+## Constructor takes a dictionary structured the same way as provided
+## by the DialogueRunner for GDScript's "text" value
+## Similar to Yarn.Markup.MarkupParseResult
+class Line:
+	var text: String ## The original text, with all parsed markers removed.
+
+	## List of attributes from the MarkupAttribute, in an array of dictionaries
+	##
+	## The dictionary is as follows:
+	## "length": int - the number of text elements in the plain text that this attribute covers.
+	## "name": String - the name of the attribute.
+	## "position": int - the position in the plain text where this attribute begins.
+    ## "properties": Dictionary - the properties associated with this attribute.
+	var attributes: Array
+
+	func _init(data: Dictionary = {}) -> void:
+		if data.is_empty(): return
+		if !data.has_all(["text", "attributes"]):
+			push_error("YarnSpinner GDScript: Can't create LocalizedLine.Line, incorrect or missing data")
+			return
+
+		text = data["text"]
+		attributes = data["attributes"]
+
+	func text_for_attribute(name: String) -> String:
+		var attr := try_get_attribute_with_name(name)
+
+		if attr.is_empty():
+			return ""
+		elif attr["length"] <= 0 :
+			return ""
+		else:
+			return text.substr(attr["position"], attr["length"])
+
+	func try_get_attribute_with_name(name: String) -> Dictionary:
+		for value: Dictionary in attributes:
+			if value["name"] == (name): return value
+
+		return {}
+
+
+## Converts a dictionary array to an array of DialogueOption's
+static func new_dialogue_option_array(data: Array) -> Array[DialogueOption]:
+	if data.is_empty():
+		push_error("YarnSpinner GDScript: Can't create DialogueOption Array, empty array")
+		return []
+
+	var return_data : Array[DialogueOption] = []
+
+	for val in data:
+		return_data.push_back(DialogueOption.new(val))
+
+	return return_data
+

--- a/addons/YarnSpinner-Godot/Runtime/Views/GDScriptHelper.gd
+++ b/addons/YarnSpinner-Godot/Runtime/Views/GDScriptHelper.gd
@@ -1,4 +1,4 @@
-class_name GDYS
+class_name YarnSpinner
 ## Helper class supporting C# to GDScript functionality
 ##
 ## This helper class creates GDScript versions of classes and other helper functions
@@ -15,16 +15,18 @@ class DialogueOption:
 	var line: LocalizedLine ## The line for this dialogue option
 	var is_available: bool ## Indicates whether this value should be presented as available
 
-	func _init(data: Dictionary = {}) -> void:
-		if data.is_empty(): return
+	static func from_dictionary(data: Dictionary = {}) -> DialogueOption:
 		if !data.has_all(["dialogue_option_id", "line"]):
 			push_error("YarnSpinner GDScript: Can't create DialogueOption, incorrect or missing data")
 			return
 
-		dialogue_option_id = data["dialogue_option_id"]
-		text_id = data["text_id"]
-		line = LocalizedLine.new(data["line"])
-		is_available = data["is_available"]
+		var option := DialogueOption.new()
+		option.dialogue_option_id = data["dialogue_option_id"]
+		option.text_id = data["text_id"]
+		option.line = LocalizedLine.from_dictionary(data["line"])
+		option.is_available = data["is_available"]
+
+		return option
 
 
 ## Represents a line, ready to be presented to the user in the localisation they have specified.
@@ -33,8 +35,8 @@ class DialogueOption:
 ## by the DialogueRunner for GDScript
 ## Mirrors YarnSpinnerGodot.LocalizedLine class
 class LocalizedLine:
-	var text: Line ## The underlying Line class for this line
-	var text_without_character_name: Line ## The original text with the character attribute removed
+	var text: MarkupParseResult ## The underlying MarkupParseResult class for this line
+	var text_without_character_name: MarkupParseResult ## The original text with the character attribute removed
 	var text_id: String ## DialogueLine's ID
 	var raw_text: String ## DialogueLine's unparsed text
 	var substitutions: Array ## DialogueLine's inline expression's substitution
@@ -49,26 +51,28 @@ class LocalizedLine:
 			else:
 				return name["properties"][0]["name"]
 
-	func _init(data: Dictionary = {}) -> void:
-		if data.is_empty(): return
+	static func from_dictionary(data: Dictionary = {}) -> LocalizedLine:
 		if !data.has_all(["text", "metadata"]):
 			push_error("YarnSpinner GDScript: Can't create LocalizedLine, incorrect or missing data")
 			return
 
-		text = Line.new(data["text"])
-		text_without_character_name = Line.new(data["text_without_character_name"])
-		text_id = data["text_id"]
-		raw_text = data["raw_text"]
-		substitutions = data["substitutions"]
-		metadata = data["metadata"]
+		var locline := LocalizedLine.new()
+		locline.text = MarkupParseResult.from_dictionary(data["text"])
+		locline.text_without_character_name = MarkupParseResult.from_dictionary(data["text_without_character_name"])
+		locline.text_id = data["text_id"]
+		locline.raw_text = data["raw_text"]
+		locline.substitutions = data["substitutions"]
+		locline.metadata = data["metadata"]
+
+		return locline
 
 
-## Line mirroring the MarkupParseResult values
+## MarkupParseResult mirroring the MarkupParseResult values
 ##
 ## Constructor takes a dictionary structured the same way as provided
 ## by the DialogueRunner for GDScript's "text" value
 ## Similar to Yarn.Markup.MarkupParseResult
-class Line:
+class MarkupParseResult:
 	var text: String ## The original text, with all parsed markers removed.
 
 	## List of attributes from the MarkupAttribute, in an array of dictionaries
@@ -80,15 +84,18 @@ class Line:
     ## "properties": Dictionary - the properties associated with this attribute.
 	var attributes: Array
 
-	func _init(data: Dictionary = {}) -> void:
-		if data.is_empty(): return
+	static func from_dictionary(data: Dictionary = {}) -> MarkupParseResult:
 		if !data.has_all(["text", "attributes"]):
-			push_error("YarnSpinner GDScript: Can't create LocalizedLine.Line, incorrect or missing data")
+			push_error("YarnSpinner GDScript: Can't create MarkupParseResult, incorrect or missing data")
 			return
 
-		text = data["text"]
-		attributes = data["attributes"]
+		var line := MarkupParseResult.new()
+		line.text = data["text"]
+		line.attributes = data["attributes"]
 
+		return line
+
+	## Returns the substring of Text covered by named attribute Position and Length properties.
 	func text_for_attribute(name: String) -> String:
 		var attr := try_get_attribute_with_name(name)
 
@@ -99,6 +106,7 @@ class Line:
 		else:
 			return text.substr(attr["position"], attr["length"])
 
+	## Gets the first attribute with the specified name, if present.
 	func try_get_attribute_with_name(name: String) -> Dictionary:
 		for value: Dictionary in attributes:
 			if value["name"] == (name): return value
@@ -107,7 +115,7 @@ class Line:
 
 
 ## Converts a dictionary array to an array of DialogueOption's
-static func new_dialogue_option_array(data: Array) -> Array[DialogueOption]:
+static func dialogue_options_from_array(data: Array) -> Array[DialogueOption]:
 	if data.is_empty():
 		push_error("YarnSpinner GDScript: Can't create DialogueOption Array, empty array")
 		return []
@@ -115,7 +123,7 @@ static func new_dialogue_option_array(data: Array) -> Array[DialogueOption]:
 	var return_data : Array[DialogueOption] = []
 
 	for val in data:
-		return_data.push_back(DialogueOption.new(val))
+		return_data.push_back(DialogueOption.from_dictionary(val))
 
 	return return_data
 

--- a/addons/YarnSpinner-Godot/Runtime/Views/GDScriptHelper.gd.uid
+++ b/addons/YarnSpinner-Godot/Runtime/Views/GDScriptHelper.gd.uid
@@ -1,0 +1,1 @@
+uid://d17e4lsgk1pjx

--- a/addons/YarnSpinner-Godot/Runtime/Views/GDScriptPresenterAdapter.cs
+++ b/addons/YarnSpinner-Godot/Runtime/Views/GDScriptPresenterAdapter.cs
@@ -97,15 +97,34 @@ public partial class GDScriptPresenterAdapter : Node, DialogueViewBase
     public static Godot.Collections.Dictionary LocalizedLineToDict(LocalizedLine dialogueLine)
     {
         var dialogueLineDict = new Godot.Collections.Dictionary();
+
+        dialogueLineDict["raw_text"] = dialogueLine.RawText;
+        dialogueLineDict["text_id"] = dialogueLine.TextID;
+
         var metadataArray = new Godot.Collections.Array();
         metadataArray.AddRange(dialogueLine.Metadata ?? Array.Empty<string>());
         dialogueLineDict["metadata"] = metadataArray;
 
-        var textDict = new Godot.Collections.Dictionary();
-        textDict["text"] = dialogueLine.Text.Text;
-        textDict["text_without_character_name"] = dialogueLine.TextWithoutCharacterName.Text;
+        var textDict = MarkupParseResultToDict(dialogueLine.Text);
+        textDict["text_without_character_name"] = dialogueLine.TextWithoutCharacterName.Text; // for backwards compatibility
+
+        dialogueLineDict["text"] = textDict;
+        dialogueLineDict["text_without_character_name"] = MarkupParseResultToDict(dialogueLine.TextWithoutCharacterName);
+
+        var subList = new Godot.Collections.Array();
+        subList.AddRange(dialogueLine.Substitutions ?? Array.Empty<String>());
+        dialogueLineDict["substitutions"] = subList;
+
+        return dialogueLineDict;
+    }
+
+    public static Godot.Collections.Dictionary MarkupParseResultToDict(MarkupParseResult text)
+    {
+        var returnValue = new Godot.Collections.Dictionary();
+        returnValue["text"] = text.Text;
+
         var attributesList = new Godot.Collections.Array();
-        foreach (var attribute in dialogueLine.Text.Attributes)
+        foreach (var attribute in text.Attributes)
         {
             var attributeDict = new Godot.Collections.Dictionary();
             attributeDict["name"] = attribute.Name;
@@ -132,9 +151,8 @@ public partial class GDScriptPresenterAdapter : Node, DialogueViewBase
             attributesList.Add(attributeDict);
         }
 
-        textDict["attributes"] = attributesList;
-        dialogueLineDict["text"] = textDict;
-        return dialogueLineDict;
+        returnValue["attributes"] = attributesList;
+        return returnValue;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Added GDScript classes that mirror `LocalizedLine`, `DialogueOption`, and some parts of `MarkupParsedResult` so GDScript presenters have the same information as their C# counterparts. Updated the helper functions in `GDScriptPresenterAdapter.cs` to pass through data that was missing before.

Also updated the GDScript Integration sample to use the new helper classes, which really cut down on the complexity of the samples.

I think the helper functions from the Presenter Adapter should be moved somewhere else more reasonable, maybe on the DialogueRunner.

Additional Notes:
- I think the Line Provider (`LineProviderBehaviour`) should have a helper function to get a dictionary formatted like the one it gets from `run_line_async` so GDScript's can fetch a line by its ID. I haven't gotten around to this yet, and the helper functions might get moved soon anyways.
- The GDScript "Line" helper class is missing the `DeleteRange` method from the `MarkupParseResult` its supposed to be mirroring, otherwise it would be 1:1 to how `LocalizedLine` works in C#