### PR TITLE
Fix invalid **.cs glob breaking incremental builds

### DIFF
--- a/addons/YarnSpinner-Godot/SourceGenerator/YarnSpinnerGodotSourceGenerator.csproj
+++ b/addons/YarnSpinner-Godot/SourceGenerator/YarnSpinnerGodotSourceGenerator.csproj
@@ -12,8 +12,7 @@
         <DefineConstants>YARN_SOURCE_GENERATION_DEBUG_LOGGING</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
-        <Compile Include="**.cs"/>
-        <Compile Include="Analyser.cs" />
+        <Compile Include="*.cs"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="All" ExcludeAssets="runtime" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
*.cs covers all sources since they all live in the project root. Also drops the explicit Analyser.cs entry that was producing CS2002.

**.cs is treated as a literal filename, so the Compile item resolves to a nonexistent path and FastUpToDateCheck reruns CoreCompile every build. csc.exe expands the pattern heuristically, so builds still work, but the analyzer dll's mtime advances each time and cascades into a full rebuild in consumers

<details>
  <summary>Running dotnet build twice, before:</summary>
  

```
❯ dotnet build
Restore complete (0.5s)
  YarnSpinnerGodotSourceGenerator succeeded with 1 warning(s) (0.4s) → addons/YarnSpinner-Godot/SourceGenerator/bin/Debug/netstandard2.0/YarnSpinnerGodot.SourceCodeGenerator.dll
    CSC : warning CS2002: Source file '/Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/SourceGenerator/Analyser.cs' specified multiple times
  YarnSpinner-Godot succeeded with 3 warning(s) (2.3s) → .godot/mono/temp/bin/Debug/YarnSpinner-Godot.dll
    /Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/Runtime/YarnJSONContext.cs(19,22): warning SYSLIB1220: The 'JsonConverterAttribute' type 'Yarn.Compiler.StringOrListOfStringsConverter' specified on member 'Yarn.Compiler.Project.Definitions' is not a converter type or does not contain an accessible parameterless constructor. (https://learn.microsoft.com/dotnet/fundamentals/syslib-diagnostics/syslib1220)
    /Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/Runtime/Async/DialoguePresenterBase.cs(84,27): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
    /usr/local/share/dotnet/sdk/9.0.300/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(323,5): warning NETSDK1206: Found version-specific or distribution-specific runtime identifier(s): alpine-arm, alpine-arm64, alpine-x64. Affected libraries: SQLitePCLRaw.lib.e_sqlite3. In .NET 8.0 and higher, assets for version-specific and distribution-specific runtime identifiers will not be found by default. See https://aka.ms/dotnet/rid-usage for details.

Build succeeded with 4 warning(s) in 3.4s
❯ dotnet build
Restore complete (0.4s)
  YarnSpinnerGodotSourceGenerator succeeded with 1 warning(s) (0.3s) → addons/YarnSpinner-Godot/SourceGenerator/bin/Debug/netstandard2.0/YarnSpinnerGodot.SourceCodeGenerator.dll
    CSC : warning CS2002: Source file '/Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/SourceGenerator/Analyser.cs' specified multiple times
  YarnSpinner-Godot succeeded with 2 warning(s) (1.5s) → .godot/mono/temp/bin/Debug/YarnSpinner-Godot.dll
    /Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/Runtime/YarnJSONContext.cs(19,22): warning SYSLIB1220: The 'JsonConverterAttribute' type 'Yarn.Compiler.StringOrListOfStringsConverter' specified on member 'Yarn.Compiler.Project.Definitions' is not a converter type or does not contain an accessible parameterless constructor. (https://learn.microsoft.com/dotnet/fundamentals/syslib-diagnostics/syslib1220)
    /Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/Runtime/Async/DialoguePresenterBase.cs(84,27): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.

Build succeeded with 3 warning(s) in 2.4s
```
  
</details>



<details>
  <summary>After:</summary>
  

```
❯ dotnet build
Restore complete (0.4s)
  YarnSpinnerGodotSourceGenerator succeeded (0.3s) → addons/YarnSpinner-Godot/SourceGenerator/bin/Debug/netstandard2.0/YarnSpinnerGodot.SourceCodeGenerator.dll
  YarnSpinner-Godot succeeded with 2 warning(s) (2.8s) → .godot/mono/temp/bin/Debug/YarnSpinner-Godot.dll
    /Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/Runtime/YarnJSONContext.cs(19,22): warning SYSLIB1220: The 'JsonConverterAttribute' type 'Yarn.Compiler.StringOrListOfStringsConverter' specified on member 'Yarn.Compiler.Project.Definitions' is not a converter type or does not contain an accessible parameterless constructor. (https://learn.microsoft.com/dotnet/fundamentals/syslib-diagnostics/syslib1220)
    /Work/YarnSpinner-Godot/addons/YarnSpinner-Godot/Runtime/Async/DialoguePresenterBase.cs(84,27): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.

Build succeeded with 2 warning(s) in 3.8s
❯ dotnet build
Restore complete (0.4s)
  YarnSpinnerGodotSourceGenerator succeeded (0.1s) → addons/YarnSpinner-Godot/SourceGenerator/bin/Debug/netstandard2.0/YarnSpinnerGodot.SourceCodeGenerator.dll
  YarnSpinner-Godot succeeded (0.1s) → .godot/mono/temp/bin/Debug/YarnSpinner-Godot.dll

Build succeeded in 0.8s
```
</details>
